### PR TITLE
Add conversion to keras CV format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [ "3.8", "3.9", "3.10" ]
+        python: [ "3.9", "3.10", "3.11" ]
     name: python-${{ matrix.python }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -190,10 +190,12 @@ affine_transform = TFCombineAffine(
 
 # Apply transformations.
 auto_tune = tf.data.AUTOTUNE
-ds = ds
-  .map(TFRandomCrop(probability=0.5), num_parallel_calls=auto_tune)
-  .map(affine_transform, num_parallel_calls=auto_tune)
-  .map(TFResize((256, 256)), num_parallel_calls=auto_tune)
+ds = (
+    ds
+    .map(TFRandomCrop(probability=0.5), num_parallel_calls=auto_tune)
+    .map(affine_transform, num_parallel_calls=auto_tune)
+    .map(TFResize((256, 256)), num_parallel_calls=auto_tune)
+)
 
 # In the Dataset `map` call, the parameter `num_parallel_calls` can be set to,
 # e.g., tf.data.AUTOTUNE, for better performance. See docs for TensorFlow Dataset.
@@ -340,11 +342,13 @@ from targetran.utils import image_only
 ```
 ```python
 # TensorFlow.
-ds = ds \
-    .map(image_only(TFRandomCrop())) \
-    .map(image_only(affine_transform)) \
-    .map(image_only(TFResize((256, 256)))) \
+ds = (
+    ds
+    .map(image_only(TFRandomCrop()))
+    .map(image_only(affine_transform))
+    .map(image_only(TFResize((256, 256))))
     .batch(32)  # Conventional batching can be used for classification setup.
+)
 ```
 ```python
 # PyTorch.

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ affine_transform = TFCombineAffine(
 # Apply transformations.
 auto_tune = tf.data.AUTOTUNE
 ds = (
-    ds
-    .map(TFRandomCrop(probability=0.5), num_parallel_calls=auto_tune)
-    .map(affine_transform, num_parallel_calls=auto_tune)
-    .map(TFResize((256, 256)), num_parallel_calls=auto_tune)
+  ds
+  .map(TFRandomCrop(probability=0.5), num_parallel_calls=auto_tune)
+  .map(affine_transform, num_parallel_calls=auto_tune)
+  .map(TFResize((256, 256)), num_parallel_calls=auto_tune)
 )
 
 # In the Dataset `map` call, the parameter `num_parallel_calls` can be set to,
@@ -343,11 +343,11 @@ from targetran.utils import image_only
 ```python
 # TensorFlow.
 ds = (
-    ds
-    .map(image_only(TFRandomCrop()))
-    .map(image_only(affine_transform))
-    .map(image_only(TFResize((256, 256))))
-    .batch(32)  # Conventional batching can be used for classification setup.
+  ds
+  .map(image_only(TFRandomCrop()))
+  .map(image_only(affine_transform))
+  .map(image_only(TFResize((256, 256))))
+  .batch(32)  # Conventional batching can be used for classification setup.
 )
 ```
 ```python

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here comes Targetran to fill the gap.
 
 # Installation
 
-Tested for Python 3.8, 3.9, and 3.10.
+Tested for Python 3.9, 3.10, and 3.11.
 
 The best way to install Targetran with its dependencies is from PyPI:
 ```shell

--- a/README.md
+++ b/README.md
@@ -139,61 +139,61 @@ labels_seq = [
 import tensorflow as tf
 
 from targetran.tf import (
-    seqs_to_tf_dataset,
-    TFCombineAffine,
-    TFRandomFlipLeftRight,
-    TFRandomFlipUpDown,    
-    TFRandomRotate,
-    TFRandomShear,
-    TFRandomTranslate,
-    TFRandomCrop,
-    TFResize,
+  to_tf_dataset,
+  TFCombineAffine,
+  TFRandomFlipLeftRight,
+  TFRandomFlipUpDown,
+  TFRandomRotate,
+  TFRandomShear,
+  TFRandomTranslate,
+  TFRandomCrop,
+  TFResize,
 )
 
 # Convert the above data sequences into a TensorFlow Dataset.
 # Users can have their own way to create the Dataset, as long as for each iteration 
 # it returns a tuple of tensors for a single example: (image, bboxes, labels).
-ds = seqs_to_tf_dataset(image_seq, bboxes_seq, labels_seq)
+ds = to_tf_dataset(image_seq, bboxes_seq, labels_seq)
 
 # Alternatively, users can provide a sequence of image paths instead of image tensors/arrays,
 # and set `image_seq_is_paths=True`. In that case, the actual image loading will be done during
 # the dataset operation (i.e., lazy-loading). This is especially useful when dealing with huge data.
-ds = seqs_to_tf_dataset(image_paths, bboxes_seq, labels_seq, image_seq_is_paths=True)
+ds = to_tf_dataset(image_paths, bboxes_seq, labels_seq, image_seq_is_paths=True)
 
 # The affine transformations can be combined into one operation for better performance.
 # Note that cropping and resizing are not affine and cannot be combined.
 # Option (1):
 affine_transform = TFCombineAffine(
-    [TFRandomRotate(probability=0.8),  # Probability to include each affine transformation step 
-     TFRandomShear(probability=0.6),   # can be specified, otherwise the default value is used.
-     TFRandomTranslate(),              # Thus, the number of selected steps could vary.
-     TFRandomFlipLeftRight(),
-     TFRandomFlipUpDown()],
-    probability=1.0  # Probability to apply this single combined transformation.
+  [TFRandomRotate(probability=0.8),  # Probability to include each affine transformation step 
+   TFRandomShear(probability=0.6),  # can be specified, otherwise the default value is used.
+   TFRandomTranslate(),  # Thus, the number of selected steps could vary.
+   TFRandomFlipLeftRight(),
+   TFRandomFlipUpDown()],
+  probability=1.0  # Probability to apply this single combined transformation.
 )
 # Option (2):
 # Alternatively, one can decide the exact number of randomly selected transformations,
 # e.g., use only any two of them. This could be a better option because too many 
 # transformation steps may deform the images too much.
 affine_transform = TFCombineAffine(
-    [TFRandomRotate(),  # Individual `probability` has no effect in this approach.
-     TFRandomShear(),
-     TFRandomTranslate(),
-     TFRandomFlipLeftRight(),
-     TFRandomFlipUpDown()],
-    num_selected_transforms=2,  # Only two steps from the list will be selected.
-    selected_probabilities=[0.5, 0.0, 0.3, 0.2, 0.0],  # Must sum up to 1.0, if given.
-    keep_order=True,  # If True, the selected steps must be performed in the given order.
-    probability=1.0  # Probability to apply this single combined transformation.
+  [TFRandomRotate(),  # Individual `probability` has no effect in this approach.
+   TFRandomShear(),
+   TFRandomTranslate(),
+   TFRandomFlipLeftRight(),
+   TFRandomFlipUpDown()],
+  num_selected_transforms=2,  # Only two steps from the list will be selected.
+  selected_probabilities=[0.5, 0.0, 0.3, 0.2, 0.0],  # Must sum up to 1.0, if given.
+  keep_order=True,  # If True, the selected steps must be performed in the given order.
+  probability=1.0  # Probability to apply this single combined transformation.
 )
 # Please refer to the API manual for more parameter options.
 
 # Apply transformations.
 auto_tune = tf.data.AUTOTUNE
-ds = ds \
-    .map(TFRandomCrop(probability=0.5), num_parallel_calls=auto_tune) \
-    .map(affine_transform, num_parallel_calls=auto_tune) \
-    .map(TFResize((256, 256)), num_parallel_calls=auto_tune)
+ds = ds
+  .map(TFRandomCrop(probability=0.5), num_parallel_calls=auto_tune)
+  .map(affine_transform, num_parallel_calls=auto_tune)
+  .map(TFResize((256, 256)), num_parallel_calls=auto_tune)
 
 # In the Dataset `map` call, the parameter `num_parallel_calls` can be set to,
 # e.g., tf.data.AUTOTUNE, for better performance. See docs for TensorFlow Dataset.

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,7 +96,7 @@ for more details.
 - [`TFRandomCrop`](#randomcrop-tfrandomcrop)
 - [`TFResize`](#resize-tfresize)
 - [`to_tf`](#to_tf)
-- [`seqs_to_tf_dataset`](#seqs_to_tf_dataset)
+- [`to_tf_dataset`](#to_tf_dataset)
 - [`tf_flip_left_right`](#flip_left_right-tf_flip_left_right)
 - [`tf_flip_up_down`](#flip_up_down-tf_flip_up_down)
 - [`tf_rotate`](#rotate-tf_rotate)
@@ -258,7 +258,7 @@ Convert array sequences to TensorFlow (eager) tensor sequences.
 - Returns
   - Tuple of tensors: `(image_seq, bboxes_seq, labels_seq)`.
 
-### `seqs_to_tf_dataset`
+### `to_tf_dataset`
 Convert array sequences to a TensorFlow Dataset.
 - Parameters
   - `image_seq`, `bboxes_seq`, `labels_seq`,

--- a/examples/kaggle/run_tf_dataset_kaggle_example.py
+++ b/examples/kaggle/run_tf_dataset_kaggle_example.py
@@ -118,7 +118,7 @@ def make_tf_dataset(
     labels_seq = [
         annotation_dict[image_id]["labels"] for image_id in image_dict.keys()
     ]
-    return tt.seqs_to_tf_dataset(image_seq, bboxes_seq, labels_seq)
+    return tt.to_tf_dataset(image_seq, bboxes_seq, labels_seq)
 
 
 def save_plots(ds: tf.data.Dataset, num_images: int) -> None:

--- a/examples/local/run_tf_dataset_local_example.py
+++ b/examples/local/run_tf_dataset_local_example.py
@@ -14,7 +14,7 @@ import numpy.typing
 import tensorflow as tf
 
 from targetran.tf import (
-    seqs_to_tf_dataset,
+    to_tf_dataset,
     TFCombineAffine,
     TFRandomFlipLeftRight,
     TFRandomRotate,
@@ -92,7 +92,7 @@ def make_tf_dataset(
     labels_seq = [
         annotation_dict[image_id]["labels"] for image_id in image_dict.keys()
     ]
-    return seqs_to_tf_dataset(image_seq, bboxes_seq, labels_seq)
+    return to_tf_dataset(image_seq, bboxes_seq, labels_seq)
 
 
 def plot(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+keras-cv>=0.9.0
 matplotlib
 numpy>=1.22.0
 opencv-python

--- a/targetran/tf/__init__.py
+++ b/targetran/tf/__init__.py
@@ -1,7 +1,8 @@
 from ._tf import (
     to_tf as to_tf,
     to_tf_dataset as to_tf_dataset,
-    to_keras_cv as to_keras_cv,
+    to_keras_cv_dict as to_keras_cv_dict,
+    to_keras_cv_model_input as to_keras_cv_model_input,
     tf_flip_left_right as tf_flip_left_right,
     tf_flip_up_down as tf_flip_up_down,
     tf_rotate as tf_rotate,

--- a/targetran/tf/__init__.py
+++ b/targetran/tf/__init__.py
@@ -1,6 +1,6 @@
 from ._tf import (
     to_tf as to_tf,
-    seqs_to_tf_dataset as seqs_to_tf_dataset,
+    to_tf_dataset as to_tf_dataset,
     tf_flip_left_right as tf_flip_left_right,
     tf_flip_up_down as tf_flip_up_down,
     tf_rotate as tf_rotate,

--- a/targetran/tf/__init__.py
+++ b/targetran/tf/__init__.py
@@ -1,6 +1,7 @@
 from ._tf import (
     to_tf as to_tf,
     to_tf_dataset as to_tf_dataset,
+    to_keras_cv as to_keras_cv,
     tf_flip_left_right as tf_flip_left_right,
     tf_flip_up_down as tf_flip_up_down,
     tf_rotate as tf_rotate,

--- a/targetran/tf/_tf.py
+++ b/targetran/tf/_tf.py
@@ -118,6 +118,7 @@ def to_tf_dataset(
 def to_keras_cv(
         ds: tf.data.Dataset,
         batch_size: Optional[int] = None,
+        drop_remainder: bool = True,
         to_dense: bool = True,
         max_num_bboxes: Optional[int] = None,
         fill_value: int = -1,
@@ -126,7 +127,7 @@ def to_keras_cv(
 
     ds = ds.map(lambda i, b, l: (i, {"boxes": b, "classes": l}))
     if batch_size:
-        ds = ds.ragged_batch(batch_size=batch_size)
+        ds = ds.ragged_batch(batch_size=batch_size, drop_remainder=drop_remainder)
     if to_dense:
         ds = ds.map(
             lambda i, d: (

--- a/targetran/tf/_tf.py
+++ b/targetran/tf/_tf.py
@@ -87,9 +87,7 @@ def to_tf_dataset(
 
     if image_seq_is_paths:
         ds_image = tf.data.Dataset.from_tensor_slices(tf_image_seq)
-        ds_image = ds_image.map(
-            load_tf_image, deterministic=True, num_parallel_calls=tf.data.AUTOTUNE
-        )
+        ds_image = ds_image.map(load_tf_image)
     else:
         ds_image = tf.data.Dataset.from_tensor_slices(tf.ragged.stack(tf_image_seq))
 

--- a/targetran/tf/_tf.py
+++ b/targetran/tf/_tf.py
@@ -75,7 +75,7 @@ def to_tf(
     return tf_image_seq, tf_bboxes_seq, tf_labels_seq
 
 
-def seqs_to_tf_dataset(
+def to_tf_dataset(
         image_seq: Sequence[T],
         bboxes_seq: Sequence[T],
         labels_seq: Sequence[T],

--- a/targetran/tf/_tf.py
+++ b/targetran/tf/_tf.py
@@ -122,7 +122,7 @@ def to_keras_cv(
         max_num_bboxes: Optional[int] = None,
         fill_value: int = -1,
 ) -> tf.data.Dataset:
-    import keras_cv
+    import keras_cv  # type: ignore
 
     ds = ds.map(lambda i, b, l: (i, {"boxes": b, "classes": l}))
     if batch_size:

--- a/targetran/tf/_tf.py
+++ b/targetran/tf/_tf.py
@@ -115,6 +115,30 @@ def seqs_to_tf_dataset(
     return ds
 
 
+def to_keras_cv(
+        ds: tf.data.Dataset,
+        batch_size: Optional[int] = None,
+        to_dense: bool = True,
+        max_num_bboxes: Optional[int] = None,
+        fill_value: int = -1,
+) -> tf.data.Dataset:
+    import keras_cv
+
+    ds = ds.map(lambda i, b, l: (i, {"boxes": b, "classes": l}))
+    if batch_size:
+        ds = ds.ragged_batch(batch_size=batch_size)
+    if to_dense:
+        ds = ds.map(
+            lambda i, d: (
+                i,
+                keras_cv.bounding_box.to_dense(
+                    d, max_boxes=max_num_bboxes, default_value=fill_value
+                )
+            )
+        )
+    return ds
+
+
 def _tf_get_affine_dependency() -> _AffineDependency:
     return _AffineDependency(
         _tf_convert, tf.shape, tf.reshape, tf.expand_dims, tf.squeeze,

--- a/targetran/tf/_tf.py
+++ b/targetran/tf/_tf.py
@@ -126,15 +126,15 @@ def to_keras_cv(
     ds = ds.map(lambda i, b, l: (i, {"boxes": b, "classes": l}))
     if batch_size:
         ds = ds.ragged_batch(batch_size=batch_size, drop_remainder=drop_remainder)
-    if to_dense:
-        ds = ds.map(
-            lambda i, d: (
-                i,
-                keras_cv.bounding_box.to_dense(
-                    d, max_boxes=max_num_bboxes, default_value=fill_value
-                )
-            )
-        )
+
+    ds = ds.map(
+        lambda i, d: {
+            "images": i,
+            "bounding_boxes": keras_cv.bounding_box.to_dense(
+                d, max_boxes=max_num_bboxes, default_value=fill_value
+            ) if to_dense else d,
+        }
+    )
     return ds
 
 

--- a/tests/_test.py
+++ b/tests/_test.py
@@ -16,7 +16,7 @@ from targetran.np import (
 )
 from targetran.tf import (
     to_tf,
-    seqs_to_tf_dataset,
+    to_tf_dataset,
     tf_flip_left_right,
     tf_flip_up_down,
     tf_rotate,
@@ -560,8 +560,8 @@ class TestTransform(unittest.TestCase):
 
 class TestConversion(unittest.TestCase):
 
-    def test_seqs_to_tf_dataset(self) -> None:
-        ds = seqs_to_tf_dataset(
+    def test_to_tf_dataset(self) -> None:
+        ds = to_tf_dataset(
             ORIGINAL_IMAGE_SEQ, ORIGINAL_BBOXES_SEQ, ORIGINAL_LABELS_SEQ
         )
         for i, (image, bboxes, labels) in enumerate(ds):
@@ -575,7 +575,7 @@ class TestConversion(unittest.TestCase):
                 np.allclose(ORIGINAL_LABELS_SEQ[i], labels.numpy())
             )
 
-        ds_image_only = seqs_to_tf_dataset(
+        ds_image_only = to_tf_dataset(
             ORIGINAL_IMAGE_SEQ, [], []
         )
         for i, (image, _, _) in enumerate(ds_image_only):

--- a/tests/run_tf_dataset_test.py
+++ b/tests/run_tf_dataset_test.py
@@ -42,7 +42,7 @@ def make_np_data() -> Tuple[Sequence[NDAnyArray],
 def main() -> None:
     image_seq, bboxes_seq, labels_seq = make_np_data()
 
-    ds = targetran.tf.seqs_to_tf_dataset(image_seq, bboxes_seq, labels_seq)
+    ds = targetran.tf.to_tf_dataset(image_seq, bboxes_seq, labels_seq)
 
     print("-------- Raw data --------")
 
@@ -74,7 +74,7 @@ def main() -> None:
 
     print("-------- Random transform with combine-affine --------")
 
-    ds = targetran.tf.seqs_to_tf_dataset(image_seq, bboxes_seq, labels_seq)
+    ds = targetran.tf.to_tf_dataset(image_seq, bboxes_seq, labels_seq)
 
     affine_transforms = targetran.tf.TFCombineAffine([
         targetran.tf.TFRandomRotate(probability=1.0),


### PR DESCRIPTION
- Drop support for Python 3.8; added support for 3.11.
- Rename `seqs_to_tf_dataset` to `to_tf_dataset`.
- Add `keras-cv` into `requirements.txt`.
- Add new functions `to_keras_cv_dict` and `to_keras_cv_model_input`.
- Update docs.

