### PR TITLE
Default empty seq inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ ds = to_tf_dataset(image_seq, bboxes_seq, labels_seq)
 
 # Alternatively, users can provide a sequence of image paths instead of image tensors/arrays,
 # and set `image_seq_is_paths=True`. In that case, the actual image loading will be done during
-# the dataset operation (i.e., lazy-loading). This is especially useful when dealing with huge data.
+# the dataset operation (i.e., lazy-loading). This is useful when dealing with huge data.
 ds = to_tf_dataset(image_paths, bboxes_seq, labels_seq, image_seq_is_paths=True)
 
 # The affine transformations can be combined into one operation for better performance.
@@ -374,6 +374,8 @@ from targetran.utils import image_only
 ```
 ```python
 # TensorFlow.
+ds = to_tf_dataset(image_seq)
+
 ds = (
   ds
   .map(image_only(TFRandomCrop()))

--- a/docs/API.md
+++ b/docs/API.md
@@ -253,7 +253,7 @@ Resize the input image.
 ### `to_tf`
 Convert array sequences to TensorFlow (eager) tensor sequences.
 - Parameters
-  - `image_seq`, `bboxes_seq`, `labels_seq`, 
+  - `image_seq`, `bboxes_seq` (default empty tuple), `labels_seq` (default empty tuple), 
     `image_seq_is_paths` (`boolean`, default `False`): 
     Please refer to the [data format](../README.md#data-format) and the 
     illustration for [TensorFlow Dataset](../README.md#tensorflow-dataset).
@@ -263,7 +263,7 @@ Convert array sequences to TensorFlow (eager) tensor sequences.
 ### `to_tf_dataset`
 Convert array sequences to a TensorFlow Dataset.
 - Parameters
-  - `image_seq`, `bboxes_seq`, `labels_seq`,
+  - `image_seq`, `bboxes_seq` (default empty tuple), `labels_seq` (default empty tuple),
     `image_seq_is_paths` (`boolean`, default `False`):
     Please refer to the [data format](../README.md#data-format) and the 
     illustration for [TensorFlow Dataset](../README.md#tensorflow-dataset).

--- a/targetran/tf/_tf.py
+++ b/targetran/tf/_tf.py
@@ -51,8 +51,8 @@ def load_tf_image(image_path: str) -> tf.Tensor:
 
 def to_tf(
         image_seq: Sequence[T],
-        bboxes_seq: Sequence[T],
-        labels_seq: Sequence[T],
+        bboxes_seq: Sequence[T] = (),
+        labels_seq: Sequence[T] = (),
         image_seq_is_paths: bool = False,
 ) -> Tuple[Sequence[tf.Tensor], Sequence[tf.Tensor], Sequence[tf.Tensor]]:
     """
@@ -77,8 +77,8 @@ def to_tf(
 
 def to_tf_dataset(
         image_seq: Sequence[T],
-        bboxes_seq: Sequence[T],
-        labels_seq: Sequence[T],
+        bboxes_seq: Sequence[T] = (),
+        labels_seq: Sequence[T] = (),
         image_seq_is_paths: bool = False,
 ) -> tf.data.Dataset:
     tf_image_seq, tf_bboxes_seq, tf_labels_seq = to_tf(


### PR DESCRIPTION
- Default empty tuple for `bboxes_seq` and `labels_seq` for `to_tf` and `to_tf_dataset` functions.
- Fix `mypy` issues.